### PR TITLE
Temporarily disable media notifications to work around crash

### DIFF
--- a/weblayer/browser/java/org/chromium/weblayer_private/TabImpl.java
+++ b/weblayer/browser/java/org/chromium/weblayer_private/TabImpl.java
@@ -314,8 +314,9 @@ public final class TabImpl extends ITab.Stub {
         // addObserver() calls to observer when added.
         WebLayerAccessibilityUtil.get().addObserver(mAccessibilityObserver);
 
-        mMediaSessionHelper = new MediaSessionHelper(
-                mWebContents, MediaSessionManager.createMediaSessionHelperDelegate(this));
+        // Disable to workaround https://github.com/neevaco/neeva-android/issues/739
+        //mMediaSessionHelper = new MediaSessionHelper(
+        //        mWebContents, MediaSessionManager.createMediaSessionHelperDelegate(this));
 
         GestureListenerManager.fromWebContents(mWebContents)
                 .addListener(new GestureStateListener() {


### PR DESCRIPTION
This is accomplished by just not creating a per tab MediaSessionHelper instance.