### PR TITLE
Use proper package name to resolve resources

### DIFF
--- a/weblayer/browser/java/org/chromium/weblayer_private/WebLayerImpl.java
+++ b/weblayer/browser/java/org/chromium/weblayer_private/WebLayerImpl.java
@@ -135,6 +135,8 @@ public final class WebLayerImpl extends IWebLayer.Stub {
     public static final String PREF_LAST_VERSION_CODE =
             "org.chromium.weblayer.last_version_code_used";
 
+    private static final String WEBLAYER_PACKAGE_NAME = "org.chromium.weblayer.support";
+
     // When the weblayer implementation is included as part of the same package as the app,
     // assume it is located within a split named with this value.
     private static final String WEBLAYER_SAME_PACKAGE_SPLIT_NAME = "weblayer_support";
@@ -681,8 +683,10 @@ public final class WebLayerImpl extends IWebLayer.Stub {
         } catch (Resources.NotFoundException e) {
         }
         id &= 0x00ffffff;
-        id |= (0x01000000
-                * getPackageId(context, WebViewFactory.getLoadedPackageInfo().packageName));
+        // TODO(darin): Hard coding this package name here breaks support for bundling
+        // as part of the system WebView. It would be better to determine this from the
+        // Context somehow.
+        id |= (0x01000000 * getPackageId(context, WEBLAYER_PACKAGE_NAME));
         return id;
     }
 
@@ -716,7 +720,7 @@ public final class WebLayerImpl extends IWebLayer.Stub {
             ApplicationInfo appInfo = remoteContext.getApplicationInfo();
             for (int i = 0; i < appInfo.splitNames.length; ++i) {
                 if (appInfo.splitNames[i].equals(WEBLAYER_SAME_PACKAGE_SPLIT_NAME)) {
-                    packageName = "org.chromium.weblayer.support";
+                    packageName = WEBLAYER_PACKAGE_NAME;
                     packagePath = appInfo.splitSourceDirs[i];
                     break;
                 }


### PR DESCRIPTION
For icons in notifications, WebLayer uses the Icon.createWithResource
method that takes a package name and a resource ID. (Not sure why it
doesn't use the createWithResource variant that takes a Context.)

When WebLayer is bundled as a feature module, the package name ends up
being that of the embedding application.

The resource IDs that ordinarily have a 0x24 prefix need to be adjusted
so that the system can resolve those IDs against the given package name
of the embedding app. The forceAddAssetPaths method, used by WebLayer
to make resources with a prefix of 0x24 work, does not work in this case
probably because another app is trying to resolve the resource IDs using
a different context.

That means we need to know which package ID is assigned to the WebLayer
APK. In both configurations, both as a feature split and when we are
just using WebLayerSupport.apk directly, that can be done by querying
the package ID of "org.chromium.weblayer.support".

Then we can adjust the resource IDs to that package ID and we are good.