### PR TITLE
Rework how rules are passed to renderers and support null

### DIFF
--- a/components/neeva/browser/content_filter_rules_config.cc
+++ b/components/neeva/browser/content_filter_rules_config.cc
@@ -77,27 +77,16 @@ void ContentFilterRulesConfig::StopFiltering() {
   ConfigChanged();
 }
 
-void ContentFilterRulesConfig::AddReceiver(
-    mojo::PendingReceiver<mojom::ContentFilterRulesProvider> receiver) {
-  receiver_set_.Add(this, std::move(receiver));
-}
+void ContentFilterRulesConfig::AddListener(
+    mojo::PendingRemote<mojom::ContentFilterRulesListener> remote) {
+  auto listener_id = listeners_.Add(std::move(remote));
 
-void ContentFilterRulesConfig::RefreshRules(
-    int64_t current_generation_num, RefreshRulesCallback callback) {
-  if (rules_generation_num_ == current_generation_num) {
-    refresh_rules_callbacks_.push_back(
-        base::BindOnce(&ContentFilterRulesConfig::SendRulesToClient,
-                       weak_factory_.GetWeakPtr(), std::move(callback)));
-  } else {
-    SendRulesToClient(std::move(callback));
-  }
+  listeners_.Get(listener_id)->OnReceiveNewRules(GetRules());
 }
 
 ContentFilterRulesConfig::ContentFilterRulesConfig() = default;
 
 void ContentFilterRulesConfig::ConfigChanged() {
-  ++rules_generation_num_;
-
   if (is_notify_pending_) {
     return;
   }
@@ -108,22 +97,16 @@ void ContentFilterRulesConfig::ConfigChanged() {
   // into a single update.
   base::SequencedTaskRunnerHandle::Get()->PostTask(
       FROM_HERE,
-      base::BindOnce(&ContentFilterRulesConfig::NotifyCallbacks,
+      base::BindOnce(&ContentFilterRulesConfig::NotifyListeners,
                      weak_factory_.GetWeakPtr()));
 }
 
-void ContentFilterRulesConfig::NotifyCallbacks() {
+void ContentFilterRulesConfig::NotifyListeners() {
   is_notify_pending_ = false;
 
-  auto callbacks = std::move(refresh_rules_callbacks_);
-  for (auto& callback : callbacks) {
-    std::move(callback).Run();
+  for (auto& listener : listeners_) {
+    listener->OnReceiveNewRules(GetRules());
   }
-}
-
-void ContentFilterRulesConfig::SendRulesToClient(
-    RefreshRulesCallback callback) const {
-  std::move(callback).Run(rules_generation_num_, GetRules());
 }
 
 mojom::ContentFilterRulesPtr ContentFilterRulesConfig::GetRules() const {

--- a/components/neeva/browser/content_filter_rules_config.h
+++ b/components/neeva/browser/content_filter_rules_config.h
@@ -13,7 +13,7 @@
 #include "base/observer_list.h"
 #include "base/supports_user_data.h"
 #include "components/neeva/common/content_filtering_service.mojom.h"
-#include "mojo/public/cpp/bindings/receiver_set.h"
+#include "mojo/public/cpp/bindings/remote_set.h"
 #include "mojo/public/cpp/system/buffer.h"
 
 namespace content {
@@ -24,8 +24,7 @@ namespace neeva {
 
 // Stored on each content::BrowserContext and holds the current rules
 // configuration.
-class ContentFilterRulesConfig : public base::SupportsUserData::Data,
-                                 public mojom::ContentFilterRulesProvider {
+class ContentFilterRulesConfig : public base::SupportsUserData::Data {
  public:
   ~ContentFilterRulesConfig() override;
 
@@ -42,20 +41,15 @@ class ContentFilterRulesConfig : public base::SupportsUserData::Data,
   void StartFiltering();
   void StopFiltering();
 
-  void AddReceiver(
-      mojo::PendingReceiver<mojom::ContentFilterRulesProvider> receiver);
-
-  // mojom::ContentFilterRulesProvider methods:
-  void RefreshRules(
-      int64_t current_generation_num, RefreshRulesCallback callback) override;
+  void AddListener(
+      mojo::PendingRemote<mojom::ContentFilterRulesListener> remote);
 
  private:
   static const int kUserDataKey = 0;
 
   ContentFilterRulesConfig();
   void ConfigChanged();
-  void NotifyCallbacks();
-  void SendRulesToClient(RefreshRulesCallback callback) const;
+  void NotifyListeners();
 
   // Returns current rules. Return nullptr if there are no rules / if filtering
   // is disabled.
@@ -67,13 +61,7 @@ class ContentFilterRulesConfig : public base::SupportsUserData::Data,
   bool is_filtering_enabled_ = false;
   bool is_notify_pending_ = false;
 
-  // This value is incremented each time the rules are updated. Initialized
-  // to 0 to signify that rules_ are not generated yet.
-  int64_t rules_generation_num_ = 0;
-
-  std::vector<base::OnceClosure> refresh_rules_callbacks_;
-
-  mojo::ReceiverSet<mojom::ContentFilterRulesProvider> receiver_set_;
+  mojo::RemoteSet<mojom::ContentFilterRulesListener> listeners_;
 
   base::WeakPtrFactory<ContentFilterRulesConfig> weak_factory_{this};
 };

--- a/components/neeva/browser/content_filtering_service.cc
+++ b/components/neeva/browser/content_filtering_service.cc
@@ -36,19 +36,15 @@ void ContentFilteringService::AddInterface(
       content::GetUIThreadTaskRunner({}));
 }
 
-void ContentFilteringService::Log(const std::string& message) {
-  LOG(ERROR) << ">>> " << message;
-}
-
-void ContentFilteringService::GetRulesProvider(
-    mojo::PendingReceiver<mojom::ContentFilterRulesProvider> receiver) {
+void ContentFilteringService::AddRulesListener(
+    mojo::PendingRemote<mojom::ContentFilterRulesListener> remote) {
   auto* rph = content::RenderProcessHost::FromID(render_process_id_);
   if (!rph) {
     LOG(ERROR) << "No RenderProcessHost for ID";
     return;
   }
-  ContentFilterRulesConfig::GetOrCreate(rph->GetBrowserContext())->AddReceiver(
-      std::move(receiver));
+  ContentFilterRulesConfig::GetOrCreate(rph->GetBrowserContext())->AddListener(
+      std::move(remote));
 }
 
 void ContentFilteringService::OnContentFiltered(

--- a/components/neeva/browser/content_filtering_service.h
+++ b/components/neeva/browser/content_filtering_service.h
@@ -17,10 +17,8 @@ class ContentFilteringService : public mojom::ContentFilteringService {
       service_manager::BinderRegistry* registry, int render_process_id);
 
   // mojom::ContentFilteringService methods:
-  void Log(const std::string& message) override;
-  void GetRulesProvider(
-      mojo::PendingReceiver<mojom::ContentFilterRulesProvider> receiver)
-          override;
+  void AddRulesListener(
+      mojo::PendingRemote<mojom::ContentFilterRulesListener> remote) override;
   void OnContentFiltered(
       int32_t render_frame_id, mojom::ContentFilterActionPtr action) override;
 

--- a/components/neeva/common/content_filtering_service.mojom
+++ b/components/neeva/common/content_filtering_service.mojom
@@ -21,22 +21,12 @@ struct ContentFilterAction {
   string host;
 };
 
-interface ContentFilterRulesProvider {
-  // Fetching rules:
-  // - On startup, child processes call RefreshRules passing a `current_generation_num`
-  //   of `0`, indicating that it has no rules currently.
-  // - Upon receiving new rules, child processes will immediately call `RefreshRules`
-  //   again this time passing the value of `new_generation_num` that they received.
-  //   The service will respond only when it has new rules to provide.
-  RefreshRules(int64 current_generation_num) =>
-      (int64 new_generation_num, ContentFilterRules rules);
+interface ContentFilterRulesListener {
+  OnReceiveNewRules(ContentFilterRules? rules);
 };
 
 interface ContentFilteringService {
-  Log(string message);
-
-  // Used to make "Hanging GET" style requests for any rules updates.
-  GetRulesProvider(pending_receiver<ContentFilterRulesProvider> receiver);
+  AddRulesListener(pending_remote<ContentFilterRulesListener> listener);
 
   // When a child process filters content, it calls OnContentFiltered to let the
   // service know about it. `render_frame_id` identifies the frame in which content

--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -43,22 +43,14 @@ ContentFilteringAgent::ContentFilteringAgent(
     blink::ThreadSafeBrowserInterfaceBrokerProxy* broker)
     : task_runner_(base::SequencedTaskRunnerHandle::Get()) {
   broker->GetInterface(service_.BindNewPipeAndPassReceiver());
-  RefreshRules();
+
+  service_->AddRulesListener(receiver_.BindNewPipeAndPassRemote());
 }
 
 std::unique_ptr<blink::URLLoaderThrottle> ContentFilteringAgent::CreateThrottle(
     int render_frame_id, const blink::WebURLRequest& request) {
   return std::make_unique<ContentFilter>(
       base::WrapRefCounted(this), render_frame_id, request);
-}
-
-void ContentFilteringAgent::Log(const std::string& message) {
-  if (task_runner_->RunsTasksInCurrentSequence()) {
-    service_->Log(message);
-  } else {
-    task_runner_->PostTask(
-        FROM_HERE, base::BindOnce(&ContentFilteringAgent::Log, this, message));
-  }
 }
 
 void ContentFilteringAgent::OnContentFiltered(
@@ -124,26 +116,16 @@ void ContentFilteringAgent::DeleteOnCorrectThread() const {
   }
 }
 
-void ContentFilteringAgent::RefreshRules() {
-  if (!rules_provider_) {
-    service_->GetRulesProvider(rules_provider_.BindNewPipeAndPassReceiver());
-  }
-  rules_provider_->RefreshRules(
-      current_generation_num_,
-      base::BindOnce(&ContentFilteringAgent::OnApplyNewRules, this));
-}
-
-void ContentFilteringAgent::OnApplyNewRules(
-    int64_t new_generation_num, mojom::ContentFilterRulesPtr new_rules) {
-  current_generation_num_ = new_generation_num;
-
+void ContentFilteringAgent::OnReceiveNewRules(
+    mojom::ContentFilterRulesPtr new_rules) {
   // Update the matcher.
-  {
-    base::AutoLock locked(rules_lock_);
+  base::AutoLock locked(rules_lock_);
 
-    matcher_.reset();
+  matcher_.reset();
+  rules_data_.reset();
 
-    rules_ = std::move(new_rules);
+  rules_ = std::move(new_rules);
+  if (rules_) {
     rules_data_ = MapRegion(std::move(rules_->rules_data_fd),
                             rules_->rules_data_offset,
                             rules_->rules_data_size);
@@ -151,13 +133,9 @@ void ContentFilteringAgent::OnApplyNewRules(
       matcher_ = std::make_unique<UrlPatternIndexMatcher>(
           flat::GetUrlPatternIndex(rules_data_->data()));
     } else {
-      Log("Mapping the region failed!");
+      LOG(ERROR) << "Mapping the region failed!";
     }
   }
-
-  // Kick-off another hanging refresh, waiting for the browser-side to let us know
-  // when it has new rules for us.
-  RefreshRules();
 }
 
 }  // namespace neeva

--- a/components/neeva/renderer/content_filtering_agent.h
+++ b/components/neeva/renderer/content_filtering_agent.h
@@ -40,7 +40,8 @@ enum class ContentFilteringPolicy {
 };
 
 class ContentFilteringAgent
-    : public base::RefCountedThreadSafe<ContentFilteringAgent,
+    : public mojom::ContentFilterRulesListener,
+      public base::RefCountedThreadSafe<ContentFilteringAgent,
                                         ContentFilteringAgentDeleter> {
  public:
   explicit ContentFilteringAgent(
@@ -50,26 +51,25 @@ class ContentFilteringAgent
       int render_frame_id, const blink::WebURLRequest& request);
 
   // The following methods may be called on a background thread.
-  void Log(const std::string& message);
   void OnContentFiltered(
       int32_t render_frame_id, mojom::ContentFilterActionPtr action);
   ContentFilteringPolicy GetPolicyForRequest(
       const GURL& url, const url::Origin& first_party_origin,
       url_pattern_index::proto::ElementType element_type) const;
 
+  // mojom::ContentFilterRulesListener methods:
+  void OnReceiveNewRules(mojom::ContentFilterRulesPtr new_rules) override;
+
  private:
   friend struct ContentFilteringAgentDeleter;
 
-  ~ContentFilteringAgent();
+  ~ContentFilteringAgent() override;
   void DeleteOnCorrectThread() const;
-  void RefreshRules();
-  void OnApplyNewRules(
-      int64_t new_generation_num, mojom::ContentFilterRulesPtr new_rules);
 
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
   mojo::Remote<mojom::ContentFilteringService> service_;
-  mojo::Remote<mojom::ContentFilterRulesProvider> rules_provider_;
-  int64_t current_generation_num_ = 0;
+
+  mojo::Receiver<mojom::ContentFilterRulesListener> receiver_{this};
 
   // Acquire |rules_lock_| before accessing any of the following fields.
   mutable base::Lock rules_lock_;


### PR DESCRIPTION
Previously the browser process would happily send back a null rules object
to the renderer, but because RefreshRules was declared to not receive a
null rules object, the Mojo connection would be disconnected. As a result,
the renderer would never be told to stop filtering (which is what a null
rules object means).

This PR also simplifies how new rules are passed to a renderer. Instead of 
the old clunky callback system with generation numbers, now a listener
interface is implemented by each ContentFilteringAgent and passed to
the service via a new AddRulesListener method. (This is not essential to
fixing the bug.)

Also while updating the IPC, removes the unnecessary Log method.
Normal base/logging works just fine from the renderer process.

Issue neevaco/neeva-android/issues/629