### PR TITLE
Fix 105 Upgrade problem by using GetPrimaryMainFrame() Rename

### DIFF
--- a/weblayer/browser/tab_impl.cc
+++ b/weblayer/browser/tab_impl.cc
@@ -947,7 +947,7 @@ base::android::ScopedJavaLocalRef<jobjectArray> TabImpl::GetContentFilterHosts(
   std::vector<std::string> hosts;
 
   auto* stats = neeva::ContentFilterStats::GetForCurrentDocument(
-      web_contents_->GetMainFrame());
+      web_contents_->GetPrimaryMainFrame());
   if (stats) {
     for (const auto& it : stats->data()) {
       hosts.push_back(it.first);
@@ -962,7 +962,7 @@ jint TabImpl::GetContentFilterCountForHost(
   int count = 0;
 
   auto* stats = neeva::ContentFilterStats::GetForCurrentDocument(
-      web_contents_->GetMainFrame());
+      web_contents_->GetPrimaryMainFrame());
   if (stats) {
     auto it =
         stats->data().find(base::android::ConvertJavaStringToUTF8(env, host));


### PR DESCRIPTION
There was a autoninja build error after using Chromium's new 105.0.5195.79 tag:
```
ysroot=../../third_party/android_ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot -fvisibility-inlines-hidden -Wno-deprecated-declarations -c ../../weblayer/browser/tab_impl.cc -o obj/weblayer/weblayer_lib_base/tab_impl.o
../../weblayer/browser/tab_impl.cc:950:22: error: no member named 'GetMainFrame' in 'content::WebContents'
      web_contents_->GetMainFrame());
      ~~~~~~~~~~~~~~~^
../../weblayer/browser/tab_impl.cc:965:22: error: no member named 'GetMainFrame' in 'content::WebContents'
      web_contents_->GetMainFrame());
      ~~~~~~~~~~~~~~~^
2 errors generated.
[51159/52245] CXX obj/weblayer/weblayer_lib_base/weblayer_browser_interface_binders.o
```

After looking at the new commits from neeva-dev-105: https://github.com/neevaco/chromium/commit/88d7b2e74349cbf8b3e15b61cc0663d65f9d1873

It was a simple rename fix of `GetMainFrame()` to `GetPrimaryMainFrame()`. 