### PR TITLE
Exclude unneeded browser sandbox java sources

### DIFF
--- a/neeva/snapshot-release.sh
+++ b/neeva/snapshot-release.sh
@@ -17,8 +17,13 @@ cp $src/apks/WebLayerSupport.apk $out
 cp $src/apks/WebLayerShell.apk $out
 cp $src/args.gn $out
 
+get_list_of_public_java_sources() {
+  # Exclude unneeded browser sandbox code.
+  find org/chromium/weblayer -name \*.java | grep -v BrowserSandboxService.java
+}
+
 (cd $src/../../weblayer/public/java && zip -r $out/client-res.zip res)
-(cd $src/../../weblayer/public/java && zip -r $out/client-java.zip $(find . -name \*.java))
+(cd $src/../../weblayer/public/java && zip -r $out/client-java.zip $(get_list_of_public_java_sources))
 (cd $src/../../weblayer/browser/java && zip -r $out/client-java.zip $(find org/chromium/weblayer_private/interfaces -name \*.java))
 (cd $src/gen/weblayer/public/java && zip -r $out/client-java.zip org/chromium/weblayer/WebLayerClientVersionConstants.java)
 (cd $src/../../weblayer/browser/java && zip -r $out/client-aidl.zip $(find org/chromium/weblayer_private/interfaces -name \*.aidl))


### PR DESCRIPTION
This change does two things:
1. Avoid including Java files under `weblayer/public/java/org/chromium/browserfragment`
2. Exclude `weblayer/public/java/org/chromium/weblayer/BrowserSandboxService.java`

These files appear to be about using WebLayer via an Android service that runs in another process. We want to use WebLayer directly from within our embedding app, so this service indirection is not needed and gets in the way.