### PR TITLE
Allow clients to query filter stats by rules file

### DIFF
--- a/components/neeva/browser/content_filter_rules_config.cc
+++ b/components/neeva/browser/content_filter_rules_config.cc
@@ -14,7 +14,22 @@
 namespace neeva {
 
 // static
+const char* ContentFilterRulesConfig::kValidRulesFiles[2] = {
+  "easyprivacy",
+  "easylist"
+};
+
+// static
 const int ContentFilterRulesConfig::kUserDataKey;
+
+// static
+bool ContentFilterRulesConfig::IsValidRulesFile(const std::string& file) {
+  for (const auto* valid_file : kValidRulesFiles) {
+    if (file == valid_file)
+      return true;
+  }
+  return false;
+}
 
 ContentFilterRulesConfig::~ContentFilterRulesConfig() = default;
 
@@ -37,6 +52,10 @@ ContentFilterRulesConfig* ContentFilterRulesConfig::GetOrCreate(
 }
 
 void ContentFilterRulesConfig::EnableRulesFile(const std::string& file) {
+  if (!IsValidRulesFile(file)) {
+    LOG(ERROR) << "Unexpected rules file: " << file;
+    return;
+  }
   rules_files_enabled_.insert(file);
   ConfigChanged();
 }
@@ -135,6 +154,7 @@ mojom::ContentFilterRulesPtr ContentFilterRulesConfig::GetRules() const {
       continue;
     }
 
+    data->rules_name = file;
     data->rules_data_fd = mojo::PlatformHandle(std::move(fd));
     data->rules_data_offset = region.offset;
     data->rules_data_size = region.size;

--- a/components/neeva/browser/content_filter_rules_config.h
+++ b/components/neeva/browser/content_filter_rules_config.h
@@ -26,6 +26,9 @@ namespace neeva {
 // configuration.
 class ContentFilterRulesConfig : public base::SupportsUserData::Data {
  public:
+  static const char* kValidRulesFiles[2];
+  static bool IsValidRulesFile(const std::string& rules_file);
+
   ~ContentFilterRulesConfig() override;
 
   static ContentFilterRulesConfig* Get(

--- a/components/neeva/browser/content_filter_stats.cc
+++ b/components/neeva/browser/content_filter_stats.cc
@@ -2,13 +2,51 @@
 
 #include "components/neeva/browser/content_filter_stats.h"
 
+#include "components/neeva/browser/content_filter_rules_config.h"
+
 namespace neeva {
 
 ContentFilterStats::~ContentFilterStats() = default;
 
-void ContentFilterStats::RecordFilteredHost(const std::string& host) {
+void ContentFilterStats::RecordFilteredHost(
+    const std::string& rules_file, const std::string& host) {
   // TODO: Consider mapping a.foo.com to foo.com here instead of downstream.
-  hosts_to_counts_[host] += 1;
+  data_[rules_file][host] += 1;
+}
+
+void ContentFilterStats::GetHostsForFilter(
+    const std::string& rules_file, std::vector<std::string>* hosts) const {
+  if (rules_file != "*") {
+    auto it = data_.find(rules_file);
+    if (it != data_.end()) {
+      for (const auto& entry : it->second) {
+        hosts->push_back(entry.first);
+      }
+    }
+  } else {
+    for (const auto* filename : ContentFilterRulesConfig::kValidRulesFiles) {
+      GetHostsForFilter(filename, hosts);
+    }
+  }
+}
+
+int ContentFilterStats::GetHostCountsForFilter(
+    const std::string& rules_file, const std::string& host) const {
+  int count = 0;
+  if (rules_file != "*") {
+    auto it = data_.find(rules_file);
+    if (it != data_.end()) {
+      auto result = it->second.find(host);
+      if (result != it->second.end()) {
+        count = result->second;
+      }
+    }
+  } else {
+    for (const auto* filename : ContentFilterRulesConfig::kValidRulesFiles) {
+      count += GetHostCountsForFilter(filename, host);
+    }
+  }
+  return count;
 }
 
 ContentFilterStats::ContentFilterStats(content::RenderFrameHost* rfh)

--- a/components/neeva/browser/content_filter_stats.h
+++ b/components/neeva/browser/content_filter_stats.h
@@ -11,12 +11,16 @@ namespace neeva {
 
 class ContentFilterStats : public content::DocumentUserData<ContentFilterStats> {
  public:
+  using HostStats = std::map<std::string /*hostname*/, int /*count*/>;
+
   ~ContentFilterStats() override;
 
-  void RecordFilteredHost(const std::string& host);
+  void RecordFilteredHost(const std::string& rules_file, const std::string& host);
 
-  const std::map<std::string, int>& data() const {
-      return hosts_to_counts_; }
+  void GetHostsForFilter(
+      const std::string& rules_file, std::vector<std::string>* hosts) const;
+  int GetHostCountsForFilter(
+      const std::string& rules_file, const std::string& host) const;
 
  private:
   explicit ContentFilterStats(content::RenderFrameHost* rfh);
@@ -24,7 +28,7 @@ class ContentFilterStats : public content::DocumentUserData<ContentFilterStats> 
   friend DocumentUserData;
   DOCUMENT_USER_DATA_KEY_DECL();
 
-  std::map<std::string, int> hosts_to_counts_;
+  std::map<std::string /*rules_file*/, HostStats> data_;
 };
 
 }  // namespace neeva

--- a/components/neeva/browser/content_filtering_service.cc
+++ b/components/neeva/browser/content_filtering_service.cc
@@ -58,7 +58,7 @@ void ContentFilteringService::OnContentFiltered(
   rfh = rfh->GetMainFrame();
 
   ContentFilterStats::GetOrCreateForCurrentDocument(rfh)->RecordFilteredHost(
-      action->host);
+      action->rules_name, action->host);
 
   auto* web_contents = content::WebContents::FromRenderFrameHost(rfh);
   if (web_contents) {

--- a/components/neeva/common/content_filtering_service.mojom
+++ b/components/neeva/common/content_filtering_service.mojom
@@ -8,6 +8,7 @@ enum ContentFilterMode {
 };
 
 struct ContentFilterData {
+  string rules_name;
   handle<platform> rules_data_fd;
   uint64 rules_data_offset;
   uint64 rules_data_size;
@@ -20,6 +21,7 @@ struct ContentFilterRules {
 };
 
 struct ContentFilterAction {
+  string rules_name;
   string host;
 };
 

--- a/components/neeva/renderer/content_filter.cc
+++ b/components/neeva/renderer/content_filter.cc
@@ -87,7 +87,9 @@ void ContentFilter::WillStartRequest(
 
   auto element_type = GetElementTypeForRequest(request_context_type_);
 
-  switch (agent_->GetPolicyForRequest(request->url, top_frame_origin_, element_type)) {
+  std::string rules_name;
+  switch (agent_->GetPolicyForRequest(
+      request->url, top_frame_origin_, element_type, &rules_name)) {
     case ContentFilteringPolicy::kAllow:
       return;
     case ContentFilteringPolicy::kBlockCookies:
@@ -102,6 +104,7 @@ void ContentFilter::WillStartRequest(
 
   // Report content filtering.
   mojom::ContentFilterActionPtr action(mojom::ContentFilterAction::New());
+  action->rules_name = rules_name;
   action->host = request->url.host();
   agent_->OnContentFiltered(render_frame_id_, std::move(action));
 }

--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -117,7 +117,7 @@ void ContentFilteringAgent::OnContentFiltered(
 
 ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
     const GURL& url, const url::Origin& first_party_origin,
-    proto::ElementType element_type) const {
+    proto::ElementType element_type, std::string* rules_name) const {
   // NOTE: Called from any thread.
   base::AutoLock locked(rules_lock_);
 
@@ -148,6 +148,7 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
     }
 
     // A match was found!
+    *rules_name = filter.rules_name;
     switch (rules_->mode) {
       case mojom::ContentFilterMode::BLOCK_COOKIES:
         return ContentFilteringPolicy::kBlockCookies;
@@ -201,6 +202,7 @@ void ContentFilteringAgent::OnReceiveNewRules(
           flat_rules->url_pattern_index());
       filter.css_matcher = std::make_unique<CssRuleListMatcher>(
           flat_rules->css_rule_list());
+      filter.rules_name = data->rules_name;
       filters_.push_back(std::move(filter));
     } else {
       LOG(ERROR) << "Mapping the region failed!";

--- a/components/neeva/renderer/content_filtering_agent.h
+++ b/components/neeva/renderer/content_filtering_agent.h
@@ -62,7 +62,8 @@ class ContentFilteringAgent
       int32_t render_frame_id, mojom::ContentFilterActionPtr action);
   ContentFilteringPolicy GetPolicyForRequest(
       const GURL& url, const url::Origin& first_party_origin,
-      url_pattern_index::proto::ElementType element_type) const;
+      url_pattern_index::proto::ElementType element_type,
+      std::string* rules_name) const;
 
   // mojom::ContentFilterRulesListener methods:
   void OnReceiveNewRules(mojom::ContentFilterRulesPtr new_rules) override;
@@ -74,6 +75,7 @@ class ContentFilteringAgent
     Filter();
     ~Filter();
     Filter(Filter&&);
+    std::string rules_name;
     std::unique_ptr<base::MemoryMappedFile> data;
     std::unique_ptr<url_pattern_index::UrlPatternIndexMatcher> url_matcher;
     std::unique_ptr<CssRuleListMatcher> css_matcher;

--- a/weblayer/browser/java/org/chromium/weblayer_private/TabImpl.java
+++ b/weblayer/browser/java/org/chromium/weblayer_private/TabImpl.java
@@ -746,12 +746,13 @@ public final class TabImpl extends ITab.Stub {
     }
 
     @Override
-    public Map getContentFilterStats() {
+    public Map getContentFilterStats(String rulesFile) {
         StrictModeWorkaround.apply();
         Map<String, Integer> map = new HashMap<>();
-        String[] hosts = TabImplJni.get().getContentFilterHosts(mNativeTab);
+        String[] hosts = TabImplJni.get().getContentFilterHosts(mNativeTab, rulesFile);
         for (int i = 0; i < hosts.length; ++i) {
-            map.put(hosts[i], TabImplJni.get().getContentFilterCountForHost(mNativeTab, hosts[i]));
+            map.put(hosts[i], TabImplJni.get().getContentFilterCountForHost(
+                mNativeTab, rulesFile, hosts[i]));
         }
         return map;
     }
@@ -1370,8 +1371,8 @@ public final class TabImpl extends ITab.Stub {
         boolean isDesktopUserAgentEnabled(long nativeTabImpl);
         void download(long nativeTabImpl, long nativeContextMenuParams);
         void destroyContextMenuParams(long contextMenuParams);
-        String[] getContentFilterHosts(long nativeTabImpl);
-        int getContentFilterCountForHost(long nativeTabImpl, String host);
+        String[] getContentFilterHosts(long nativeTabImpl, String rulesFile);
+        int getContentFilterCountForHost(long nativeTabImpl, String rulesFile, String host);
         void setContentFilterCallbackClient(long nativeTabImpl, IContentFilterCallbackClient client);
     }
 }

--- a/weblayer/browser/java/org/chromium/weblayer_private/interfaces/ITab.aidl
+++ b/weblayer/browser/java/org/chromium/weblayer_private/interfaces/ITab.aidl
@@ -88,6 +88,6 @@ interface ITab {
   void setExternalIntentInIncognitoCallbackClient(IExternalIntentInIncognitoCallbackClient client) = 33;
 
   // Neeva additions:
-  Map getContentFilterStats() = 98;
+  Map getContentFilterStats(in String rulesFile) = 98;
   void setContentFilterCallbackClient(IContentFilterCallbackClient client) = 99;
 }

--- a/weblayer/browser/tab_impl.cc
+++ b/weblayer/browser/tab_impl.cc
@@ -941,32 +941,30 @@ void TabImpl::Download(JNIEnv* env, jlong native_context_menu_params) {
 }
 
 base::android::ScopedJavaLocalRef<jobjectArray> TabImpl::GetContentFilterHosts(
-    JNIEnv* env) {
+    JNIEnv* env, const JavaParamRef<jstring>& rules_file) {
   std::vector<std::string> hosts;
 
   auto* stats = neeva::ContentFilterStats::GetForCurrentDocument(
       web_contents_->GetPrimaryMainFrame());
   if (stats) {
-    for (const auto& it : stats->data()) {
-      hosts.push_back(it.first);
-    }
+    stats->GetHostsForFilter(
+        base::android::ConvertJavaStringToUTF8(env, rules_file), &hosts);
   }
 
   return base::android::ToJavaArrayOfStrings(env, hosts);
 }
 
 jint TabImpl::GetContentFilterCountForHost(
-    JNIEnv* env, const JavaParamRef<jstring>& host) {
+    JNIEnv* env, const JavaParamRef<jstring>& rules_file,
+    const JavaParamRef<jstring>& host) {
   int count = 0;
 
   auto* stats = neeva::ContentFilterStats::GetForCurrentDocument(
       web_contents_->GetPrimaryMainFrame());
   if (stats) {
-    auto it =
-        stats->data().find(base::android::ConvertJavaStringToUTF8(env, host));
-    if (it != stats->data().end()) {
-      count = it->second;
-    }
+    count = stats->GetHostCountsForFilter(
+        base::android::ConvertJavaStringToUTF8(env, rules_file),
+        base::android::ConvertJavaStringToUTF8(env, host));
   }
 
   return count;

--- a/weblayer/browser/tab_impl.h
+++ b/weblayer/browser/tab_impl.h
@@ -196,8 +196,11 @@ class TabImpl : public Tab,
   void SetDesktopUserAgentEnabled(JNIEnv* env, jboolean enable);
   jboolean IsDesktopUserAgentEnabled(JNIEnv* env);
   void Download(JNIEnv* env, jlong native_context_menu_params);
-  base::android::ScopedJavaLocalRef<jobjectArray> GetContentFilterHosts(JNIEnv* env);
-  jint GetContentFilterCountForHost(JNIEnv* env, const base::android::JavaParamRef<jstring>& host);
+  base::android::ScopedJavaLocalRef<jobjectArray> GetContentFilterHosts(
+      JNIEnv* env, const base::android::JavaParamRef<jstring>& rules_file);
+  jint GetContentFilterCountForHost(
+      JNIEnv* env, const base::android::JavaParamRef<jstring>& rules_file,
+      const base::android::JavaParamRef<jstring>& host);
   void SetContentFilterCallbackClient(JNIEnv* env, const base::android::JavaParamRef<jobject>& client);
 #endif
 

--- a/weblayer/public/java/org/chromium/weblayer/Tab.java
+++ b/weblayer/public/java/org/chromium/weblayer/Tab.java
@@ -774,13 +774,26 @@ public class Tab {
         }
     }
 
-    public Map<String, Integer> getContentFilterStats() {
+    /**
+     * Returns the set of hostnames blocked by content filtering along with the
+     * number of times the hostname was blocked.
+     *
+     * @param rulesFile optionally specifies the rules file to query (e.g., pass
+     * "easyprivacy" to see what content was blocked by the "easyprivacy" list).
+     * Use "*" to request filter stats from all rules files combined.
+     *
+     * See also ContentFilterManager.enableRulesFile.
+     */
+    public Map<String, Integer> getContentFilterStats(String rulesFile) {
         ThreadCheck.ensureOnUiThread();
         try {
-            return (Map<String, Integer>) mImpl.getContentFilterStats();
+            return (Map<String, Integer>) mImpl.getContentFilterStats(rulesFile);
         } catch (RemoteException e) {
             throw new APICallException(e);
         }
+    }
+    public Map<String, Integer> getContentFilterStats() {
+        return getContentFilterStats("*");
     }
 
     public void setContentFilterCallback(ContentFilterCallback callback) {


### PR DESCRIPTION
Extend the WebLayer API to report content filtering stats on a per filter list basis.
This will enable the embedding app to determine if any ads were blocked or if
only trackers were blocked, for example.

The approach of providing an API to query by passing the name of the filter list
helps keep the implementation simple. An alternative would be to return the entire
data set in one go, but bridging that across the AIDL divide is a bit complicated.