### PR TITLE
Update Exclusions to exclude more BrowserFragment

### DIFF
--- a/neeva/snapshot-release.sh
+++ b/neeva/snapshot-release.sh
@@ -24,7 +24,14 @@ cp $src/args.gn $out
 
 get_list_of_public_java_sources() {
   # Exclude unneeded browser sandbox code.
-  find org/chromium/weblayer -name \*.java | egrep -v 'BrowserSandboxService.java|BrowserFragmentDelegate.java|BrowserFragmentTabDelegate.java|TabNavigationControllerProxy.java|TabParams.java|TabProxy.java|WebMessageReplyProxyProxy.java'
+  find org/chromium/weblayer -name \*.java | \
+  grep -v 'BrowserSandboxService.java' | \
+  grep -v 'BrowserFragmentDelegate.java' | \
+  grep -v 'BrowserFragmentTabDelegate.java' | \
+  grep -v 'TabNavigationControllerProxy.java' | \
+  grep -v 'TabParams.java' | \
+  grep -v 'TabProxy.java' | \
+  grep -v 'WebMessageReplyProxyProxy.java'
 }
 
 (cd $src/../../weblayer/public/java && zip -r $out/client-res.zip res)

--- a/neeva/snapshot-release.sh
+++ b/neeva/snapshot-release.sh
@@ -11,7 +11,12 @@ if [ -z "$out" ]; then
 fi
 
 echo "Taking snapshot of $src"
+if [ -e "$out" ]; then 
+  echo -n "$out already exists, hit enter to delete: "
+  read continue_confirmation
+fi
 
+rm -rf $out
 mkdir -p $out
 cp $src/apks/WebLayerSupport.apk $out
 cp $src/apks/WebLayerShell.apk $out
@@ -19,7 +24,7 @@ cp $src/args.gn $out
 
 get_list_of_public_java_sources() {
   # Exclude unneeded browser sandbox code.
-  find org/chromium/weblayer -name \*.java | grep -v BrowserSandboxService.java
+  find org/chromium/weblayer -name \*.java | egrep -v 'BrowserSandboxService.java|BrowserFragmentDelegate.java|BrowserFragmentTabDelegate.java|TabNavigationControllerProxy.java|TabParams.java|TabProxy.java|WebMessageReplyProxyProxy.java'
 }
 
 (cd $src/../../weblayer/public/java && zip -r $out/client-res.zip res)

--- a/weblayer/public/java/org/chromium/weblayer/BrowserFragment.java
+++ b/weblayer/public/java/org/chromium/weblayer/BrowserFragment.java
@@ -117,12 +117,12 @@ public final class BrowserFragment extends RemoteFragment {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
         onCreateInternal(savedInstanceState, null);
     }
 
     private void onCreateInternal(
             Bundle savedInstanceState, @Nullable TabListCallback tabListCallback) {
-        super.onCreate(savedInstanceState);
         if (mBrowser != null) {
             // If mBrowser is non-null, it means mBrowser came from a ViewModel.
             return;


### PR DESCRIPTION
* See changes to the snapshot-release file to see the new files excluded 
* Had to move super.onCreate() to the right place so our unit tests wouldn't break. 
* Adds rm -rf as part of the script