### PR TITLE
Content Filtering: Don't block requests coming from the site you are on

### DIFF
--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -136,10 +136,8 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
   // There's no point in blocking foo.com from making requests from first-party origins (e.g. foo.com). 
   // Doing so can break logins or other site functionality. 
   if (!IsThirdParty(url, first_party_origin)) {
-    if (rules_->mode == mojom::ContentFilterMode::BLOCK_COOKIES) {
-      return ContentFilteringPolicy::kBlockCookies;
-    }
-    return ContentFilteringPolicy::kAllow;
+    // Block cookies for first-party cookies to stop them from tracking users too. 
+    return ContentFilteringPolicy::kBlockCookies;
   }
 
   for (const auto& filter : filters_) {

--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -125,18 +125,20 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
     return ContentFilteringPolicy::kAllow;
   }
 
-  // There's no point in blocking foo.com from making requests from foo.com. 
-  // Doing so can break logins or other site functionality. 
-  // We may need to do better to handle x.foo.com requesting from y.foo.com. 
-  if (first_party_origin.IsSameOriginWith(url)) {
-    return ContentFilteringPolicy::kAllow;
-  }
-
   // Apply top-level host exclusions.
   // TODO: Use a set for more efficient lookup.
   auto end = rules_->top_level_host_exclusions.end();
   if (std::find(rules_->top_level_host_exclusions.begin(), end,
                 first_party_origin.host()) != end) {
+    return ContentFilteringPolicy::kAllow;
+  }
+
+  // There's no point in blocking foo.com from making requests from first-party origins (e.g. foo.com). 
+  // Doing so can break logins or other site functionality. 
+  if (!IsThirdParty(url, first_party_origin)) {
+    if (rules_->mode == mojom::ContentFilterMode::BLOCK_COOKIES) {
+      return ContentFilteringPolicy::kBlockCookies;
+    }
     return ContentFilteringPolicy::kAllow;
   }
 

--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -136,7 +136,7 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
   // There's no point in blocking foo.com from making requests from first-party origins (e.g. foo.com). 
   // Doing so can break logins or other site functionality. 
   if (!IsThirdParty(url, first_party_origin)) {
-    // Block cookies for first-party cookies to stop them from tracking users too. 
+    // Downgrade from kBlockRequests to kBlockCookies to minimize impact on sites. 
     return ContentFilteringPolicy::kBlockCookies;
   }
 

--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -125,6 +125,13 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
     return ContentFilteringPolicy::kAllow;
   }
 
+  // There's no point in blocking foo.com from making requests from foo.com. 
+  // Doing so can break logins or other site functionality. 
+  // We may need to do better to handle x.foo.com requesting from y.foo.com. 
+  if (first_party_origin.IsSameOriginWith(url)) {
+    return ContentFilteringPolicy::kAllow;
+  }
+
   // Apply top-level host exclusions.
   // TODO: Use a set for more efficient lookup.
   auto end = rules_->top_level_host_exclusions.end();


### PR DESCRIPTION
Fixes: https://github.com/neevaco/neeva-android/issues/1064

We were blocking requests with the origin (For example `foo.com`) even when we were on that same site (`foo.com`). This PR allows requests with the same origin as the site you are on. 

See code comments for some possible limitations. 