### PR TITLE
Only block cookies from the same origin when filter match found

### DIFF
--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -136,10 +136,8 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
   // There's no point in blocking foo.com from making requests from first-party origins (e.g. foo.com). 
   // Doing so can break logins or other site functionality. 
   if (!IsThirdParty(url, first_party_origin)) {
-    if (rules_->mode == mojom::ContentFilterMode::BLOCK_COOKIES) {
-      return ContentFilteringPolicy::kBlockCookies;
-    }
-    return ContentFilteringPolicy::kAllow;
+    // Block cookies for first-party cookies to stop them from tracking users too. 
+    return ContentFilteringPolicy::kBlockCookies;
   }
 
   for (const auto& filter : filters_) {

--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -125,18 +125,20 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
     return ContentFilteringPolicy::kAllow;
   }
 
-  // There's no point in blocking foo.com from making requests from foo.com. 
-  // Doing so can break logins or other site functionality. 
-  // We may need to do better to handle x.foo.com requesting from y.foo.com. 
-  if (first_party_origin.IsSameOriginWith(url)) {
-    return ContentFilteringPolicy::kAllow;
-  }
-
   // Apply top-level host exclusions.
   // TODO: Use a set for more efficient lookup.
   auto end = rules_->top_level_host_exclusions.end();
   if (std::find(rules_->top_level_host_exclusions.begin(), end,
                 first_party_origin.host()) != end) {
+    return ContentFilteringPolicy::kAllow;
+  }
+
+  // There's no point in blocking foo.com from making requests from first-party origins (e.g. foo.com). 
+  // Doing so can break logins or other site functionality. 
+  if (!IsThirdParty(url, first_party_origin)) {
+    if (rules_->mode == mojom::ContentFilterMode::BLOCK_COOKIES) {
+      return ContentFilteringPolicy::kBlockCookies;
+    }
     return ContentFilteringPolicy::kAllow;
   }
 

--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -136,7 +136,7 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
   // There's no point in blocking foo.com from making requests from first-party origins (e.g. foo.com). 
   // Doing so can break logins or other site functionality. 
   if (!IsThirdParty(url, first_party_origin)) {
-    // Block cookies for first-party cookies to stop them from tracking users too. 
+    // Downgrade from kBlockRequests to kBlockCookies to minimize impact on sites. 
     return ContentFilteringPolicy::kBlockCookies;
   }
 

--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -125,6 +125,13 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
     return ContentFilteringPolicy::kAllow;
   }
 
+  // There's no point in blocking foo.com from making requests from foo.com. 
+  // Doing so can break logins or other site functionality. 
+  // We may need to do better to handle x.foo.com requesting from y.foo.com. 
+  if (first_party_origin.IsSameOriginWith(url)) {
+    return ContentFilteringPolicy::kAllow;
+  }
+
   // Apply top-level host exclusions.
   // TODO: Use a set for more efficient lookup.
   auto end = rules_->top_level_host_exclusions.end();

--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -133,13 +133,6 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
     return ContentFilteringPolicy::kAllow;
   }
 
-  // There's no point in blocking foo.com from making requests from first-party origins (e.g. foo.com). 
-  // Doing so can break logins or other site functionality. 
-  if (!IsThirdParty(url, first_party_origin)) {
-    // Downgrade from kBlockRequests to kBlockCookies to minimize impact on sites. 
-    return ContentFilteringPolicy::kBlockCookies;
-  }
-
   for (const auto& filter : filters_) {
     if (!filter.url_matcher)
       continue;
@@ -156,6 +149,13 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
 
     // A match was found!
     *rules_name = filter.rules_name;
+    // There's no point in blocking foo.com from making requests from first-party origins (e.g. foo.com). 
+    // Doing so can break logins or other site functionality. 
+    if (!IsThirdParty(url, first_party_origin)) {
+      // Downgrade from kBlockRequests to kBlockCookies to minimize impact on sites. 
+      return ContentFilteringPolicy::kBlockCookies;
+    }
+
     switch (rules_->mode) {
       case mojom::ContentFilterMode::BLOCK_COOKIES:
         return ContentFilteringPolicy::kBlockCookies;


### PR DESCRIPTION
Fixes: https://github.com/neevaco/chromium/pull/19#discussion_r1001164300