### PR TITLE
Reduce strict mode for first-party-origin

### DIFF
--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -154,8 +154,8 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
     // There's no point in blocking foo.com from making requests from first-party origins (e.g. foo.com). 
     // Doing so can break logins or other site functionality. 
     if (!is_url_third_party) {
-      // Downgrade from kBlockRequests to kBlockCookies to minimize impact on sites. 
-      return ContentFilteringPolicy::kBlockCookies;
+      // Downgrade from kBlockRequests or kBlockCookies to kAllow minimize impact on first-party-origin sites.
+      return ContentFilteringPolicy::kAllow;
     }
 
     switch (rules_->mode) {

--- a/components/neeva/renderer/content_filtering_agent.cc
+++ b/components/neeva/renderer/content_filtering_agent.cc
@@ -125,6 +125,14 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
     return ContentFilteringPolicy::kAllow;
   }
 
+  bool is_url_third_party = IsThirdParty(url, first_party_origin);
+  // There's no point in blocking foo.com from making requests from first-party origins (e.g. foo.com). 
+  // Doing so can break logins or other site functionality. 
+  if (!is_url_third_party) {
+    // Downgrade from kBlockRequests or kBlockCookies to kAllow minimize impact on first-party-origin sites.
+    return ContentFilteringPolicy::kAllow;
+  }
+
   // Apply top-level host exclusions.
   // TODO: Use a set for more efficient lookup.
   auto end = rules_->top_level_host_exclusions.end();
@@ -133,7 +141,6 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
     return ContentFilteringPolicy::kAllow;
   }
 
-  bool is_url_third_party = IsThirdParty(url, first_party_origin);
 
   for (const auto& filter : filters_) {
     if (!filter.url_matcher)
@@ -151,12 +158,6 @@ ContentFilteringPolicy ContentFilteringAgent::GetPolicyForRequest(
 
     // A match was found!
     *rules_name = filter.rules_name;
-    // There's no point in blocking foo.com from making requests from first-party origins (e.g. foo.com). 
-    // Doing so can break logins or other site functionality. 
-    if (!is_url_third_party) {
-      // Downgrade from kBlockRequests or kBlockCookies to kAllow minimize impact on first-party-origin sites.
-      return ContentFilteringPolicy::kAllow;
-    }
 
     switch (rules_->mode) {
       case mojom::ContentFilterMode::BLOCK_COOKIES:


### PR DESCRIPTION
Since Strict Mode actually uses easylist.txt and easyprivacy.txt, more cookies are actually blocked than Standard Mode. 

This actually breaks the user's ability to login to Gmail because Google is expecting certain cookies. 

See [this slack thread](https://neevaco.slack.com/archives/C02RYG8LY8H/p1666650094056719) for more information. 

As a result, we've decided to allow all subresources (requests and cookies) that are hosted on the same origin as the first party. There isn't much value to restricting these first-party-origin cookies especially if it might break future sites. 